### PR TITLE
Set hyper to not build with default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ log = "0.3.1"
 regex = "0.1.30"
 rustc-serialize = "0.3.14"
 uuid = "0.1.17"
-hyper = "0.6"
+hyper = {version = "0.6", default-features = false}


### PR DESCRIPTION
this allows us to not have openssl built on windows since it requires gcc in mingw which is a silly dependency. We can look at fixing it at another date.