### PR TITLE
Fix nightly warnings related to lifetimes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -340,7 +340,7 @@ impl ToJson for WebDriverMessage {
     }
 }
 
-trait Parameters {
+trait Parameters: Sized {
     fn from_json(body: &Json) -> WebDriverResult<Self>;
 }
 


### PR DESCRIPTION
The following warnings appear:

```
src/command.rs:344:5: 344:56 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/command.rs:344     fn from_json(body: &Json) -> WebDriverResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/command.rs:344:5: 344:56 help: run `rustc --explain E0277` to see a detailed explanation
src/command.rs:344:5: 344:56 note: `Self` does not have a constant size known at compile-time
src/command.rs:344     fn from_json(body: &Json) -> WebDriverResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/command.rs:344:5: 344:56 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/command.rs:344     fn from_json(body: &Json) -> WebDriverResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/command.rs:344:5: 344:56 note: required by `core::result::Result`
src/command.rs:344     fn from_json(body: &Json) -> WebDriverResult<Self>;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

...because of:

https://github.com/rust-lang/rfcs/pull/1214