### PR TITLE
Implement support for extension commands.

### DIFF
--- a/src/httpapi.rs
+++ b/src/httpapi.rs
@@ -1,75 +1,77 @@
 use regex::{Regex, Captures};
+use rustc_serialize::json::Json;
 
 use hyper::method::Method;
 use hyper::method::Method::{Get, Post, Delete};
 
-use command::{WebDriverMessage};
+use command::{WebDriverCommand, WebDriverMessage, WebDriverExtensionCommand,
+              VoidWebDriverExtensionCommand};
 use error::{WebDriverResult, WebDriverError, ErrorStatus};
 
-static ROUTES: [(Method, &'static str, Route); 56] = [
-    (Post, "/session", Route::NewSession),
-    (Delete, "/session/{sessionId}", Route::DeleteSession),
-    (Post, "/session/{sessionId}/url", Route::Get),
-    (Get, "/session/{sessionId}/url", Route::GetCurrentUrl),
-    (Post, "/session/{sessionId}/back", Route::GoBack),
-    (Post, "/session/{sessionId}/forward", Route::GoForward),
-    (Post, "/session/{sessionId}/refresh", Route::Refresh),
-    (Get, "/session/{sessionId}/title", Route::GetTitle),
-    (Get, "/session/{sessionId}/window", Route::GetWindowHandle),
-    (Get, "/session/{sessionId}/window/handles", Route::GetWindowHandles),
-    (Delete, "/session/{sessionId}/window", Route::Close),
-    (Post, "/session/{sessionId}/window/size", Route::SetWindowSize),
-    (Get, "/session/{sessionId}/window/size", Route::GetWindowSize),
-    (Post, "/session/{sessionId}/window/maximize", Route::MaximizeWindow),
-    (Post, "/session/{sessionId}/window", Route::SwitchToWindow),
-    (Post, "/session/{sessionId}/frame", Route::SwitchToFrame),
-    (Post, "/session/{sessionId}/frame/parent", Route::SwitchToParentFrame),
-    (Post, "/session/{sessionId}/element", Route::FindElement),
-    (Post, "/session/{sessionId}/elements", Route::FindElements),
-    (Post, "/session/{sessionId}/element/{elementId}/element", Route::FindElementElement),
-    (Post, "/session/{sessionId}/element/{elementId}/elements", Route::FindElementElements),
-    (Get, "/session/{sessionId}/element/active", Route::GetActiveElement),
-    (Get, "/session/{sessionId}/element/{elementId}/displayed", Route::IsDisplayed),
-    (Get, "/session/{sessionId}/element/{elementId}/selected", Route::IsSelected),
-    (Get, "/session/{sessionId}/element/{elementId}/attribute/{name}", Route::GetElementAttribute),
-    (Get, "/session/{sessionId}/element/{elementId}/css/{propertyName}", Route::GetCSSValue),
-    (Get, "/session/{sessionId}/element/{elementId}/text", Route::GetElementText),
-    (Get, "/session/{sessionId}/element/{elementId}/name", Route::GetElementTagName),
-    (Get, "/session/{sessionId}/element/{elementId}/rect", Route::GetElementRect),
-    (Get, "/session/{sessionId}/element/{elementId}/enabled", Route::IsEnabled),
-    (Post, "/session/{sessionId}/execute/sync", Route::ExecuteScript),
-    (Post, "/session/{sessionId}/execute/async", Route::ExecuteAsyncScript),
-    (Get, "/session/{sessionId}/cookie", Route::GetCookies),
-    (Get, "/session/{sessionId}/cookie/{name}", Route::GetCookie),
-    (Post, "/session/{sessionId}/cookie", Route::AddCookie),
-    (Delete, "/session/{sessionId}/cookie", Route::DeleteCookies),
-    (Delete, "/session/{sessionId}/cookie/{name}", Route::DeleteCookie),
-    (Post, "/session/{sessionId}/timeouts", Route::SetTimeouts),
-    //(Post, "/session/{sessionId}/actions", Route::Actions),
-    (Post, "/session/{sessionId}/element/{elementId}/click", Route::ElementClick),
-    (Post, "/session/{sessionId}/element/{elementId}/tap", Route::ElementTap),
-    (Post, "/session/{sessionId}/element/{elementId}/clear", Route::ElementClear),
-    (Post, "/session/{sessionId}/element/{elementId}/value", Route::ElementSendKeys),
-    (Post, "/session/{sessionId}/alert/dismiss", Route::DismissAlert),
-    (Post, "/session/{sessionId}/alert/accept", Route::AcceptAlert),
-    (Get, "/session/{sessionId}/alert/text", Route::GetAlertText),
-    (Post, "/session/{sessionId}/alert/text", Route::SendAlertText),
-    (Get, "/session/{sessionId}/screenshot", Route::TakeScreenshot),
-    // TODO Remove this when > v0.5 is released. There for compatibility reasons with existing
-    //      Webdriver implementations.
-    (Get, "/session/{sessionId}/alert_text", Route::GetAlertText),
-    (Post, "/session/{sessionId}/alert_text", Route::SendAlertText),
-    (Post, "/session/{sessionId}/accept_alert", Route::AcceptAlert),
-    (Post, "/session/{sessionId}/dismiss_alert", Route::DismissAlert),
-    (Get, "/session/{sessionId}/window_handle", Route::GetWindowHandle),
-    (Get, "/session/{sessionId}/window_handles", Route::GetWindowHandles),
-    (Delete, "/session/{sessionId}/window_handle", Route::Close),
-    (Post, "/session/{sessionId}/execute_async", Route::ExecuteAsyncScript),
-    (Post, "/session/{sessionId}/execute", Route::ExecuteScript),
-];
+fn standard_routes<U:WebDriverExtensionRoute>() -> Vec<(Method, &'static str, Route<U>)> {
+    return vec![(Post, "/session", Route::NewSession),
+                (Delete, "/session/{sessionId}", Route::DeleteSession),
+                (Post, "/session/{sessionId}/url", Route::Get),
+                (Get, "/session/{sessionId}/url", Route::GetCurrentUrl),
+                (Post, "/session/{sessionId}/back", Route::GoBack),
+                (Post, "/session/{sessionId}/forward", Route::GoForward),
+                (Post, "/session/{sessionId}/refresh", Route::Refresh),
+                (Get, "/session/{sessionId}/title", Route::GetTitle),
+                (Get, "/session/{sessionId}/window", Route::GetWindowHandle),
+                (Get, "/session/{sessionId}/window/handles", Route::GetWindowHandles),
+                (Delete, "/session/{sessionId}/window", Route::Close),
+                (Post, "/session/{sessionId}/window/size", Route::SetWindowSize),
+                (Get, "/session/{sessionId}/window/size", Route::GetWindowSize),
+                (Post, "/session/{sessionId}/window/maximize", Route::MaximizeWindow),
+                (Post, "/session/{sessionId}/window", Route::SwitchToWindow),
+                (Post, "/session/{sessionId}/frame", Route::SwitchToFrame),
+                (Post, "/session/{sessionId}/frame/parent", Route::SwitchToParentFrame),
+                (Post, "/session/{sessionId}/element", Route::FindElement),
+                (Post, "/session/{sessionId}/elements", Route::FindElements),
+                (Post, "/session/{sessionId}/element/{elementId}/element", Route::FindElementElement),
+                (Post, "/session/{sessionId}/element/{elementId}/elements", Route::FindElementElements),
+                (Get, "/session/{sessionId}/element/active", Route::GetActiveElement),
+                (Get, "/session/{sessionId}/element/{elementId}/displayed", Route::IsDisplayed),
+                (Get, "/session/{sessionId}/element/{elementId}/selected", Route::IsSelected),
+                (Get, "/session/{sessionId}/element/{elementId}/attribute/{name}", Route::GetElementAttribute),
+                (Get, "/session/{sessionId}/element/{elementId}/css/{propertyName}", Route::GetCSSValue),
+                (Get, "/session/{sessionId}/element/{elementId}/text", Route::GetElementText),
+                (Get, "/session/{sessionId}/element/{elementId}/name", Route::GetElementTagName),
+                (Get, "/session/{sessionId}/element/{elementId}/rect", Route::GetElementRect),
+                (Get, "/session/{sessionId}/element/{elementId}/enabled", Route::IsEnabled),
+                (Post, "/session/{sessionId}/execute/sync", Route::ExecuteScript),
+                (Post, "/session/{sessionId}/execute/async", Route::ExecuteAsyncScript),
+                (Get, "/session/{sessionId}/cookie", Route::GetCookies),
+                (Get, "/session/{sessionId}/cookie/{name}", Route::GetCookie),
+                (Post, "/session/{sessionId}/cookie", Route::AddCookie),
+                (Delete, "/session/{sessionId}/cookie", Route::DeleteCookies),
+                (Delete, "/session/{sessionId}/cookie/{name}", Route::DeleteCookie),
+                (Post, "/session/{sessionId}/timeouts", Route::SetTimeouts),
+                //(Post, "/session/{sessionId}/actions", Route::Actions),
+                (Post, "/session/{sessionId}/element/{elementId}/click", Route::ElementClick),
+                (Post, "/session/{sessionId}/element/{elementId}/tap", Route::ElementTap),
+                (Post, "/session/{sessionId}/element/{elementId}/clear", Route::ElementClear),
+                (Post, "/session/{sessionId}/element/{elementId}/value", Route::ElementSendKeys),
+                (Post, "/session/{sessionId}/alert/dismiss", Route::DismissAlert),
+                (Post, "/session/{sessionId}/alert/accept", Route::AcceptAlert),
+                (Get, "/session/{sessionId}/alert/text", Route::GetAlertText),
+                (Post, "/session/{sessionId}/alert/text", Route::SendAlertText),
+                (Get, "/session/{sessionId}/screenshot", Route::TakeScreenshot),
+                // TODO Remove this when > v0.5 is released. There for compatibility reasons with existing
+                //      Webdriver implementations.
+                (Get, "/session/{sessionId}/alert_text", Route::GetAlertText),
+                (Post, "/session/{sessionId}/alert_text", Route::SendAlertText),
+                (Post, "/session/{sessionId}/accept_alert", Route::AcceptAlert),
+                (Post, "/session/{sessionId}/dismiss_alert", Route::DismissAlert),
+                (Get, "/session/{sessionId}/window_handle", Route::GetWindowHandle),
+                (Get, "/session/{sessionId}/window_handles", Route::GetWindowHandles),
+                (Delete, "/session/{sessionId}/window_handle", Route::Close),
+                (Post, "/session/{sessionId}/execute_async", Route::ExecuteAsyncScript),
+                (Post, "/session/{sessionId}/execute", Route::ExecuteScript),]
+}
 
 #[derive(Clone, Copy)]
-pub enum Route {
+pub enum Route<U:WebDriverExtensionRoute> {
     NewSession,
     DeleteSession,
     Get,
@@ -117,19 +119,37 @@ pub enum Route {
     AcceptAlert,
     GetAlertText,
     SendAlertText,
-    TakeScreenshot
+    TakeScreenshot,
+    Extension(U)
+}
+
+pub trait WebDriverExtensionRoute : Clone + Send + PartialEq {
+    type Command: WebDriverExtensionCommand + 'static;
+
+    fn command(&self, &Captures, &Json) -> WebDriverResult<WebDriverCommand<Self::Command>>;
+}
+
+#[derive(Clone, PartialEq)]
+pub struct VoidWebDriverExtensionRoute;
+
+impl WebDriverExtensionRoute for VoidWebDriverExtensionRoute {
+    type Command = VoidWebDriverExtensionCommand;
+
+    fn command(&self, _:&Captures, _:&Json) -> WebDriverResult<WebDriverCommand<VoidWebDriverExtensionCommand>> {
+        panic!("No extensions implemented");
+    }
 }
 
 #[derive(Clone)]
-struct RequestMatcher {
+struct RequestMatcher<U: WebDriverExtensionRoute> {
     method: Method,
     path_regexp: Regex,
-    match_type: Route
+    match_type: Route<U>
 }
 
-impl RequestMatcher {
-    pub fn new(method: Method, path: &str, match_type: Route) -> RequestMatcher {
-        let path_regexp = RequestMatcher::compile_path(path);
+impl <U: WebDriverExtensionRoute> RequestMatcher<U> {
+    pub fn new(method: Method, path: &str, match_type: Route<U>) -> RequestMatcher<U> {
+        let path_regexp = RequestMatcher::<U>::compile_path(path);
         RequestMatcher {
             method: method,
             path_regexp: path_regexp,
@@ -164,35 +184,38 @@ impl RequestMatcher {
     }
 }
 
-pub struct WebDriverHttpApi {
-    routes: Vec<(Method, RequestMatcher)>
+pub struct WebDriverHttpApi<U: WebDriverExtensionRoute> {
+    routes: Vec<(Method, RequestMatcher<U>)>,
 }
 
-impl WebDriverHttpApi {
-    pub fn new() -> WebDriverHttpApi {
-        let mut rv = WebDriverHttpApi {
-            routes: vec![]
+impl <U: WebDriverExtensionRoute> WebDriverHttpApi<U> {
+    pub fn new(extension_routes:Vec<(Method, &str, U)>) -> WebDriverHttpApi<U> {
+        let mut rv = WebDriverHttpApi::<U> {
+            routes: vec![],
         };
         debug!("Creating routes");
-        for &(ref method, ref url, ref match_type) in ROUTES.iter() {
-            rv.add(method.clone(), *url, *match_type);
+        for &(ref method, ref url, ref match_type) in standard_routes::<U>().iter() {
+            rv.add(method.clone(), *url, (*match_type).clone());
+        };
+        for &(ref method, ref url, ref extension_route) in extension_routes.iter() {
+            rv.add(method.clone(), *url, Route::Extension(extension_route.clone()));
         };
         rv
     }
 
-    fn add(&mut self, method: Method, path: &str, match_type: Route) {
+    fn add(&mut self, method: Method, path: &str, match_type: Route<U>) {
         let http_matcher = RequestMatcher::new(method.clone(), path, match_type);
         self.routes.push((method, http_matcher));
     }
 
-    pub fn decode_request(&self, method: Method, path: &str, body: &str) -> WebDriverResult<WebDriverMessage> {
+    pub fn decode_request(&self, method: Method, path: &str, body: &str) -> WebDriverResult<WebDriverMessage<U>> {
         let mut error = ErrorStatus::UnknownPath;
         for &(ref match_method, ref matcher) in self.routes.iter() {
             if method == *match_method {
                 let (method_match, captures) = matcher.get_match(method.clone(), path);
                 if captures.is_some() {
                     if method_match {
-                        return WebDriverMessage::from_http(matcher.match_type,
+                        return WebDriverMessage::from_http(matcher.match_type.clone(),
                                                            &captures.unwrap(),
                                                            body,
                                                            method == Post)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate hyper;
 extern crate regex;
 
 #[macro_use] pub mod macros;
-mod httpapi;
+pub mod httpapi;
 pub mod command;
 pub mod common;
 pub mod error;


### PR DESCRIPTION
This adds support for extension commands by adding an Extension(T:WebDriverExtensionRoute)
entry to the httpapi::Route enum and Extension(T:WebDriverExtensionCommand) to
command::WebDriverCommand. Users must pass a list of all the extension routes they want
to use when calling server::start. They will also need to ensure that their WebDriverHandler
implementation has the extesnion route type as a type argument