### PR TITLE
Add extensions `Nullable` and change `Date`s data visibility to pub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /Cargo.lock
+*~
+*.swp
+*.swo

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,7 +7,7 @@ use error::{WebDriverResult, WebDriverError, ErrorStatus};
 pub static ELEMENT_KEY: &'static str = "element-6066-11e4-a52e-4f735466cecf";
 
 #[derive(RustcEncodable, PartialEq, Clone, Debug)]
-pub struct Date(u64);
+pub struct Date(pub u64);
 
 impl Date {
     pub fn new(timestamp: u64) -> Date {
@@ -42,6 +42,14 @@ impl<T: ToJson> Nullable<T> {
             Nullable::Null => false
         }
     }
+
+    pub fn map<F, U: ToJson>(self, f: F) -> Nullable<U>
+        where F: FnOnce(T) -> U {
+        match self {
+            Nullable::Value(val) => Nullable::Value(f(val)),
+            Nullable::Null => Nullable::Null
+        }
+    }
 }
 
 impl<T: ToJson> Nullable<T> {
@@ -69,6 +77,15 @@ impl<T: ToJson> Encodable for Nullable<T> {
         match *self {
             Nullable::Value(ref x) => x.to_json().encode(s),
             Nullable::Null => s.emit_option_none()
+        }
+    }
+}
+
+impl<T: ToJson> Into<Option<T>> for Nullable<T> {
+    fn into(self) -> Option<T> {
+        match self {
+            Nullable::Value(val) => Some(val),
+            Nullable::Null => None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,25 @@ pub mod server;
 pub mod response;
 
 
-#[test]
-fn it_works() {
+#[cfg(test)]
+mod nullable_tests {
+    use super::common::Nullable;
+
+    #[test]
+    fn test_nullable_map() {
+        let mut test = Nullable::Value(21);
+
+        assert_eq!(test.map(|x| x << 1), Nullable::Value(42));
+
+        test = Nullable::Null;
+
+        assert_eq!(test.map(|x| x << 1), Nullable::Null);
+    }
+
+    #[test]
+    fn test_nullable_into() {
+        let test: Option<i32> = Nullable::Value(42).into();
+
+        assert_eq!(test, Some(42));
+    }
 }


### PR DESCRIPTION
Implement `Into<Option<T>>` and `map` for `Nullable` and change `Date`s contained data visibility to public. I also added some rules to `.gitignore` for the sanity of vim users :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraham/webdriver-rust/25)
<!-- Reviewable:end -->
