### PR TITLE
Implement Into<cookie::Cookie> for Cookie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ log = "0.3.5"
 regex = "0.1.47"
 rustc-serialize = "0.3.16"
 hyper = {version = "0.9", default-features = false}
+cookie = {version = "0.2.4"}
+time = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ extern crate log;
 extern crate rustc_serialize;
 extern crate hyper;
 extern crate regex;
+extern crate cookie;
+extern crate time;
 
 #[macro_use] pub mod macros;
 pub mod httpapi;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,9 @@
 use rustc_serialize::json;
 
 use common::{Nullable, Date};
+use cookie;
+use time;
+use std::collections::BTreeMap;
 
 #[derive(Debug)]
 pub enum WebDriverResponse {
@@ -112,6 +115,27 @@ impl Cookie {
             expiry: expiry,
             secure: secure,
             httpOnly: http_only
+        }
+    }
+}
+
+impl Into<cookie::Cookie> for Cookie {
+    fn into(self) -> cookie::Cookie {
+        cookie::Cookie {
+            name: self.name,
+            value: self.value,
+            expires: match self.expiry {
+                Nullable::Value(Date(expiry)) => {
+                    Some(time::at(time::Timespec::new(expiry as i64, 0)))
+                },
+                Nullable::Null => None
+            },
+            max_age: None,
+            domain: self.domain.into(),
+            path: self.path.into(),
+            secure: self.secure,
+            httponly: self.httpOnly,
+            custom: BTreeMap::new()
         }
     }
 }


### PR DESCRIPTION
This is largely for servo/servo#10826.

Implement `Into<cookie::Cookie>` (where cookie is [cookie-rs](https://github.com/alexcrichton/cookie-rs)). Then impl `Serialize` and `Deserialize` in `cookie-rs`.

Either way, we need one common way of representing a cookie... As long as it isn't oatmeal raisin :smile:

CC @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraham/webdriver-rust/33)
<!-- Reviewable:end -->
