### PR TITLE
Correct Error message when starting a second session. 

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -120,7 +120,7 @@ impl <T: WebDriverHandler<U>,
                         match msg.command {
                             WebDriverCommand::NewSession(_) => {
                                 Err(WebDriverError::new(
-                                    ErrorStatus::UnsupportedOperation,
+                                    ErrorStatus::SessionNotCreated,
                                     "Session is already started"))
                             },
                             _ => {


### PR DESCRIPTION
This should be throwing a Session Not Created Error as described in
http://w3c.github.io/webdriver/webdriver-spec.html#new-session step 2

This fixes https://github.com/mozilla/geckodriver/issues/174

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraham/webdriver-rust/40)
<!-- Reviewable:end -->
